### PR TITLE
Add timezone in count down date

### DIFF
--- a/index.html
+++ b/index.html
@@ -286,7 +286,7 @@
 
     <script>
       // Set the date we're counting down to
-      var countDownDate = new Date("Jul 21, 2022 00:00:00").getTime();
+      var countDownDate = new Date("Jul 21, 2022 00:00:00 GMT+0700").getTime();
 
       // Update the count down every 1 second
       var x = setInterval(function () {


### PR DESCRIPTION
Singkat cerita dua orang teman saya dari negara berbeda (Singapura dan Jepang) membuka website [kominfu.com](https://kominfu.com/) dan _countdown timer_ mereka berdua menunjukan waktu yang berbeda di saat yang sama.

Saya pun mengecek dan ternyata baris berikut tidak memasukan zona waktu sehingga _countdown timer_ akan selalu memakai zona waktu lokal dari komputer pengguna.

https://github.com/kominfu/kominfu.com/blob/c413915f8bc1fa4aa1e3f6d9ae0f3b74387df68f/index.html#L289

Saya pun menambahkan zona waktu di _contructor_ tersebut dengan asumsi tanggal dan waktu yang dimaksud adalah zona waktu WIB (GMT+7).

Cara mengetesnya dapat dengan mengubah zona waktu di komputer. Hasilnya _countdown_ akan selalu sama dan konsisten di zona waktu manapun.

<details>
<summary>Sebelum</summary>

<p>

![2022-07-19_19-33](https://user-images.githubusercontent.com/4964985/179754714-c337ecce-579e-44e4-9224-d539f0538fd8.png)

![2022-07-19_20-34](https://user-images.githubusercontent.com/4964985/179754786-25e1d503-7b35-40f8-8b86-0d1dedde1da9.png)

![2022-07-19_21-34](https://user-images.githubusercontent.com/4964985/179754834-bb1e2bef-b3d8-43c8-8da1-92a82230060a.png)
</p>
</details>

<details>
<summary>Sesudah</summary>

<p>

![2022-07-19_19-35](https://user-images.githubusercontent.com/4964985/179755281-742e18b1-69b3-48f0-bcef-c82e24c91fbb.png)

![2022-07-19_20-35](https://user-images.githubusercontent.com/4964985/179755332-60f9ebbd-d0dc-4ca0-ad46-44f89e554676.png)

![2022-07-19_21-36](https://user-images.githubusercontent.com/4964985/179755393-8cf5d72b-2fc2-409c-a570-a0387c0409a5.png)
</p>
</details> 